### PR TITLE
Readme: Explicitly call out no buildpack.yml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ $ ./scripts/package.sh
 ```
 
 This builds the buildpack's Go source using `GOOS=linux` by default. You can supply another value as the first argument to `package.sh`.
+
+## `buildpack.yml` Configurations
+
+The `npm` buildpack does not support configurations using `buildpack.yml`.


### PR DESCRIPTION
[#172333965]

Co-authored-by: Arjun Sreedharan <asreedharan@pivotal.io>