### PR TITLE
Resolves integration issues with sync script

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,2 +1,1 @@
 CODEOWNERS
-receive-github-config-updates.yml

--- a/.github/workflows/receive-github-config-updates.yml
+++ b/.github/workflows/receive-github-config-updates.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Run the sync action
       uses: paketo-buildpacks/github-config/actions/sync@master
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
       with:
         config-repo: config-repo
         current-repo: current-repo

--- a/.github/workflows/receive-github-config-updates.yml
+++ b/.github/workflows/receive-github-config-updates.yml
@@ -24,12 +24,12 @@ jobs:
         path: current-repo
 
     - name: Run the sync action
-      uses: paketo-buildpacks/config-repo/actions/sync@master
+      uses: paketo-buildpacks/github-config/actions/sync@master
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         config-repo: config-repo
         current-repo: current-repo
         config-path: "/implementation"
-        ssh-private-key: ${{ secrets.DEPLOY_KEY_PRIVATE }}
+        ssh-private-key: ${{ secrets.PAKETO_BOT_SSH_KEY }}
       id: do-sync


### PR DESCRIPTION
- renames DEPLOY_KEY_PRIVATE to PAKETO_BOT_SSH_KEY
- corrects action github repo name
- removes sync workflow from .syncignore