### PR TITLE
integration.json: override builder

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -1,3 +1,4 @@
 {
+  "builder": "index.docker.io/paketobuildpacks/builder:full-cf",
   "node-engine": "github.com/paketo-buildpacks/node-engine"
 }


### PR DESCRIPTION
This is because we have vendored tests that use node-gyp and node-gyp
requires python. python is not available on the base bionic stack which
is the default builder-stack for integration tests at the moment

Signed-off-by: Arjun Sreedharan <asreedharan@vmware.com>