### PR TITLE
Logs out the specific npm command run as the build process

### DIFF
--- a/build.go
+++ b/build.go
@@ -22,7 +22,7 @@ type BuildManager interface {
 	Resolve(workingDir, cacheDir string) (BuildProcess, error)
 }
 
-func Build(buildManager BuildManager, clock chronos.Clock, logger *scribe.Logger) packit.BuildFunc {
+func Build(buildManager BuildManager, clock chronos.Clock, logger scribe.Logger) packit.BuildFunc {
 	return func(context packit.BuildContext) (packit.BuildResult, error) {
 		logger.Title("%s %s", context.BuildpackInfo.Name, context.BuildpackInfo.Version)
 
@@ -55,7 +55,6 @@ func Build(buildManager BuildManager, clock chronos.Clock, logger *scribe.Logger
 				return packit.BuildResult{}, err
 			}
 
-			logger.Subprocess("Running 'npm install'")
 			duration, err := clock.Measure(func() error {
 				return process.Run(nodeModulesLayer.Path, nodeCacheLayer.Path, context.WorkingDir)
 			})

--- a/build_process_resolver.go
+++ b/build_process_resolver.go
@@ -29,10 +29,10 @@ type Summer interface {
 type BuildProcessResolver struct {
 	executable Executable
 	summer     Summer
-	logger     *scribe.Logger
+	logger     scribe.Logger
 }
 
-func NewBuildProcessResolver(executable Executable, summer Summer, logger *scribe.Logger) BuildProcessResolver {
+func NewBuildProcessResolver(executable Executable, summer Summer, logger scribe.Logger) BuildProcessResolver {
 	return BuildProcessResolver{
 		executable: executable,
 		summer:     summer,
@@ -85,17 +85,17 @@ func (r BuildProcessResolver) Resolve(workingDir, cacheDir string) (BuildProcess
 	case !locked && vendored, locked && vendored && !cached:
 		r.logger.Subprocess("Selected NPM build process: 'npm rebuild'")
 		r.logger.Break()
-		return NewRebuildBuildProcess(r.executable, r.summer, scribe.NewLogger(os.Stderr)), nil
+		return NewRebuildBuildProcess(r.executable, r.summer, scribe.NewLogger(os.Stdout)), nil
 
 	case !locked && !vendored:
 		r.logger.Subprocess("Selected NPM build process: 'npm install'")
 		r.logger.Break()
-		return NewInstallBuildProcess(r.executable, scribe.NewLogger(os.Stderr)), nil
+		return NewInstallBuildProcess(r.executable, scribe.NewLogger(os.Stdout)), nil
 
 	default:
 		r.logger.Subprocess("Selected NPM build process: 'npm ci'")
 		r.logger.Break()
-		return NewCIBuildProcess(r.executable, r.summer, scribe.NewLogger(os.Stderr)), nil
+		return NewCIBuildProcess(r.executable, r.summer, scribe.NewLogger(os.Stdout)), nil
 	}
 }
 

--- a/build_process_resolver_test.go
+++ b/build_process_resolver_test.go
@@ -45,7 +45,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 		buffer = bytes.NewBuffer(nil)
 		logger := scribe.NewLogger(buffer)
 
-		resolver = npm.NewBuildProcessResolver(executable, summer, &logger)
+		resolver = npm.NewBuildProcessResolver(executable, summer, logger)
 	})
 	it.After(func() {
 		Expect(os.RemoveAll(workingDir)).To(Succeed())
@@ -58,7 +58,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 				buildProcess, err := resolver.Resolve(workingDir, cacheDir)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(buildProcess).To(Equal(npm.NewInstallBuildProcess(executable, scribe.NewLogger(os.Stderr))))
+				Expect(buildProcess).To(Equal(npm.NewInstallBuildProcess(executable, scribe.NewLogger(os.Stdout))))
 
 				Expect(buffer.String()).To(ContainSubstring("Selected NPM build process: 'npm install'"))
 			})
@@ -75,7 +75,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 				buildProcess, err := resolver.Resolve(workingDir, cacheDir)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(buildProcess).To(Equal(npm.NewInstallBuildProcess(executable, scribe.NewLogger(os.Stderr))))
+				Expect(buildProcess).To(Equal(npm.NewInstallBuildProcess(executable, scribe.NewLogger(os.Stdout))))
 
 				contents, err := ioutil.ReadFile(filepath.Join(cacheDir, "npm-cache", "some-cache-file"))
 				Expect(err).NotTo(HaveOccurred())
@@ -94,7 +94,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 				buildProcess, err := resolver.Resolve(workingDir, cacheDir)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(buildProcess).To(Equal(npm.NewRebuildBuildProcess(executable, summer, scribe.NewLogger(os.Stderr))))
+				Expect(buildProcess).To(Equal(npm.NewRebuildBuildProcess(executable, summer, scribe.NewLogger(os.Stdout))))
 
 				Expect(buffer.String()).To(ContainSubstring("Selected NPM build process: 'npm rebuild'"))
 			})
@@ -114,7 +114,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 				buildProcess, err := resolver.Resolve(workingDir, cacheDir)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(buildProcess).To(Equal(npm.NewRebuildBuildProcess(executable, summer, scribe.NewLogger(os.Stderr))))
+				Expect(buildProcess).To(Equal(npm.NewRebuildBuildProcess(executable, summer, scribe.NewLogger(os.Stdout))))
 
 				contents, err := ioutil.ReadFile(filepath.Join(cacheDir, "npm-cache", "some-cache-file"))
 				Expect(err).NotTo(HaveOccurred())
@@ -134,7 +134,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 				buildProcess, err := resolver.Resolve(workingDir, cacheDir)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(buildProcess).To(Equal(npm.NewRebuildBuildProcess(executable, summer, scribe.NewLogger(os.Stderr))))
+				Expect(buildProcess).To(Equal(npm.NewRebuildBuildProcess(executable, summer, scribe.NewLogger(os.Stdout))))
 			})
 		})
 	})
@@ -150,7 +150,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 				buildProcess, err := resolver.Resolve(workingDir, cacheDir)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(buildProcess).To(Equal(npm.NewCIBuildProcess(executable, summer, scribe.NewLogger(os.Stderr))))
+				Expect(buildProcess).To(Equal(npm.NewCIBuildProcess(executable, summer, scribe.NewLogger(os.Stdout))))
 
 				Expect(buffer.String()).To(ContainSubstring("Selected NPM build process: 'npm ci'"))
 			})
@@ -171,7 +171,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 				buildProcess, err := resolver.Resolve(workingDir, cacheDir)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(buildProcess).To(Equal(npm.NewCIBuildProcess(executable, summer, scribe.NewLogger(os.Stderr))))
+				Expect(buildProcess).To(Equal(npm.NewCIBuildProcess(executable, summer, scribe.NewLogger(os.Stdout))))
 
 				contents, err := ioutil.ReadFile(filepath.Join(cacheDir, "npm-cache", "some-cache-file"))
 				Expect(err).NotTo(HaveOccurred())
@@ -196,7 +196,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 				buildProcess, err := resolver.Resolve(workingDir, cacheDir)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(buildProcess).To(Equal(npm.NewCIBuildProcess(executable, summer, scribe.NewLogger(os.Stderr))))
+				Expect(buildProcess).To(Equal(npm.NewCIBuildProcess(executable, summer, scribe.NewLogger(os.Stdout))))
 
 				contents, err := ioutil.ReadFile(filepath.Join(cacheDir, "npm-cache", "some-cache-file"))
 				Expect(err).NotTo(HaveOccurred())
@@ -259,7 +259,7 @@ func testBuildProcessResolver(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			logger := scribe.NewLogger(bytes.NewBuffer(nil))
-			resolver = npm.NewBuildProcessResolver(executable, summer, &logger)
+			resolver = npm.NewBuildProcessResolver(executable, summer, logger)
 		})
 
 		it.After(func() {

--- a/build_test.go
+++ b/build_test.go
@@ -80,7 +80,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		buffer = bytes.NewBuffer(nil)
 		logger := scribe.NewLogger(buffer)
 
-		build = npm.Build(buildManager, clock, &logger)
+		build = npm.Build(buildManager, clock, logger)
 	})
 
 	it.After(func() {
@@ -240,8 +240,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				return nil
 			}
 
-			logger := scribe.NewLogger(buffer)
-			build = npm.Build(buildManager, clock, &logger)
+			build = npm.Build(buildManager, clock, scribe.NewLogger(buffer))
 		})
 
 		it("filters out empty layers", func() {
@@ -285,8 +284,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		it.Before(func() {
 			buildProcess.RunCall.Stub = func(ld, cd, wd string) error { return nil }
 
-			logger := scribe.NewLogger(buffer)
-			build = npm.Build(buildManager, clock, &logger)
+			build = npm.Build(buildManager, clock, scribe.NewLogger(buffer))
 		})
 
 		it("filters out empty layers", func() {

--- a/ci_build_process.go
+++ b/ci_build_process.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/paketo-buildpacks/packit/fs"
 	"github.com/paketo-buildpacks/packit/pexec"
@@ -40,8 +41,6 @@ func (r CIBuildProcess) ShouldRun(workingDir string, metadata map[string]interfa
 }
 
 func (r CIBuildProcess) Run(modulesDir, cacheDir, workingDir string) error {
-	r.logger.Subprocess("Running 'npm ci'")
-
 	err := os.MkdirAll(filepath.Join(workingDir, "node_modules"), os.ModePerm)
 	if err != nil {
 		return err
@@ -58,8 +57,11 @@ func (r CIBuildProcess) Run(modulesDir, cacheDir, workingDir string) error {
 	}
 
 	buffer := bytes.NewBuffer(nil)
+	args := []string{"ci", "--unsafe-perm", "--cache", cacheDir}
+
+	r.logger.Subprocess("Running 'npm %s'", strings.Join(args, " "))
 	err = r.executable.Execute(pexec.Execution{
-		Args:   []string{"ci", "--unsafe-perm", "--cache", cacheDir},
+		Args:   args,
 		Dir:    workingDir,
 		Stdout: buffer,
 		Stderr: buffer,

--- a/install_build_process.go
+++ b/install_build_process.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/paketo-buildpacks/packit/pexec"
 	"github.com/paketo-buildpacks/packit/scribe"
@@ -38,8 +39,11 @@ func (r InstallBuildProcess) Run(modulesDir, cacheDir, workingDir string) error 
 	}
 
 	buffer := bytes.NewBuffer(nil)
+	args := []string{"install", "--unsafe-perm", "--cache", cacheDir}
+
+	r.logger.Subprocess("Running 'npm %s'", strings.Join(args, " "))
 	err = r.executable.Execute(pexec.Execution{
-		Args:   []string{"install", "--unsafe-perm", "--cache", cacheDir},
+		Args:   args,
 		Dir:    workingDir,
 		Stdout: buffer,
 		Stderr: buffer,

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -59,11 +59,8 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				Execute(name, source)
 			Expect(err).NotTo(HaveOccurred(), logs.String)
 
-			buildpackVersion, err := GetGitVersion()
-			Expect(err).ToNot(HaveOccurred())
-
 			Expect(logs).To(ContainLines(
-				fmt.Sprintf("%s %s", buildpackInfo.Buildpack.Name, buildpackVersion),
+				fmt.Sprintf("%s 1.2.3", buildpackInfo.Buildpack.Name),
 				"  Resolving installation process",
 				"    Process inputs:",
 				"      node_modules      -> \"Not found\"",
@@ -73,7 +70,7 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				"    Selected NPM build process: 'npm install'",
 				"",
 				"  Executing build process",
-				"    Running 'npm install'",
+				fmt.Sprintf("    Running 'npm install --unsafe-perm --cache /layers/%s/npm-cache'", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				MatchRegexp(`      Completed in (\d+\.\d+|\d{3})`),
 				"",
 				"  Configuring environment",

--- a/run/main.go
+++ b/run/main.go
@@ -16,10 +16,10 @@ func main() {
 	executable := pexec.NewExecutable("npm")
 	logger := scribe.NewLogger(os.Stdout)
 	checksumCalculator := fs.NewChecksumCalculator()
-	resolver := npm.NewBuildProcessResolver(executable, checksumCalculator, &logger)
+	resolver := npm.NewBuildProcessResolver(executable, checksumCalculator, logger)
 
 	packit.Run(
 		npm.Detect(packageJSONParser),
-		npm.Build(resolver, chronos.DefaultClock, &logger),
+		npm.Build(resolver, chronos.DefaultClock, logger),
 	)
 }


### PR DESCRIPTION
Instead of just saying `npm install`, we should log the entire command with all flags and options.